### PR TITLE
currentTimestamp and now function fix

### DIFF
--- a/com.ibm.streamsx.datetime/com.ibm.streamsx.datetime/functions.spl
+++ b/com.ibm.streamsx.datetime/com.ibm.streamsx.datetime/functions.spl
@@ -16,11 +16,11 @@ namespace com.ibm.streamsx.datetime;
  * Get the current time using getTimestamp().
  * Alias of `getTimestamp` with a natural name.
  */
-public timestamp now() { return getTimestamp(); }
+public stateful timestamp now() { return getTimestamp(); }
 
 /**
  * Get the current time using getTimestamp().
  * Alias of `getTimestamp` with a natural name.
  */
-public timestamp currentTimestamp() { return getTimestamp(); }
+public stateful timestamp currentTimestamp() { return getTimestamp(); }
 


### PR DESCRIPTION
Now() and currentTimestamp() function must be declared as a stateful function because getTimestamp() function is a stateful function 