### PR TITLE
Added 'default' for missingTimeExc to SPL doc and fixed comment.

### DIFF
--- a/com.ibm.streamsx.datetime/com.ibm.streamsx.datetime.convert/native.function/function.xml
+++ b/com.ibm.streamsx.datetime/com.ibm.streamsx.datetime.convert/native.function/function.xml
@@ -16,7 +16,7 @@ Convert formatted timestamp to SPL timestamp.
         <function:description>
 Convert formatted timestamp to SPL timestamp.
 @param ts String timestamp to parse.
-@param missingTimeExc Boolean flag to indicate whether to throw an exception if the timestamp does not include a time.
+@param missingTimeExc Boolean flag to indicate whether to throw an exception if the timestamp does not include a time. The default is false.
 @return SPL timestamp.
         </function:description>
         <function:prototype>public timestamp parseDateTime(rstring ts, boolean missingTimeExc)</function:prototype>

--- a/com.ibm.streamsx.datetime/impl/include/DateTimeParser.h
+++ b/com.ibm.streamsx.datetime/impl/include/DateTimeParser.h
@@ -67,7 +67,7 @@ namespace com { namespace ibm { namespace streamsx { namespace datetime { namesp
 		return cLocalAdjustor::utc_to_local(timeDate) - timeDate;
 	}
 
-	// parseDateTime accepts date as string and optionally offset update policy (default - no update)
+	// parseDateTime accepts date as a string and an optional flag if to throw exception when time is missing (default: false)
 	inline SPL::timestamp parseDateTime(std::string const& ts, bool missingTimeExc = false) {
 
 		// Define DateTimeGrammar as a static variable - thread safe


### PR DESCRIPTION
Small fixes for SPL doc and comment.